### PR TITLE
Add scroll video component demo

### DIFF
--- a/components/ScrollVideo/ScrollVideo.js
+++ b/components/ScrollVideo/ScrollVideo.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react";
+
+const ScrollVideo = () => {
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const handleScroll = () => {
+      const rect = video.getBoundingClientRect();
+      const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+      const scrollTop = window.scrollY || window.pageYOffset;
+      const offsetTop = rect.top + scrollTop;
+      const totalScroll = rect.height + windowHeight;
+      const scrollPos = scrollTop + windowHeight - offsetTop;
+      const progress = Math.min(Math.max(scrollPos / totalScroll, 0), 1);
+      if (video.duration) {
+        video.currentTime = progress * video.duration;
+      }
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <p
+        style={{
+          position: "absolute",
+          top: 10,
+          left: 10,
+          padding: "4px 8px",
+          background: "rgba(0,0,0,0.6)",
+          color: "#fff",
+          zIndex: 1,
+        }}
+      >
+        Scroll to play
+      </p>
+      <video
+        ref={videoRef}
+        src="/videos/seq.mp4"
+        style={{ width: "100%", height: "auto" }}
+        preload="auto"
+        muted
+      />
+    </div>
+  );
+};
+
+export default ScrollVideo;

--- a/components/header/Header.js
+++ b/components/header/Header.js
@@ -108,18 +108,9 @@ const Header = (props) => {
                       </Link>
                     </li>
                     <li>
-                      <a
-                        className="nav-link"
-                        activeClass="active"
-                        to="/components"
-                        href="/components"
-                        spy={true}
-                        smooth={true}
-                        duration={500}
-                        offset={-95}
-                      >
+                      <NavLink href="/components" className="nav-link">
                         Components
-                      </a>
+                      </NavLink>
                     </li>
                   </ul>
                 </div>

--- a/pages/components/index.js
+++ b/pages/components/index.js
@@ -1,10 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
+import { Dialog, Grid } from "@mui/material";
+import ScrollVideo from "../../components/ScrollVideo/ScrollVideo";
+
+const demos = [{ name: "Scroll Video", component: <ScrollVideo /> }];
 
 const ComponentsPage = () => {
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState(null);
+
+  const handleOpen = (item) => {
+    setCurrent(item);
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
   return (
-    <div>
+    <div className="container" style={{ padding: "40px 20px" }}>
       <h1>Components</h1>
-      <p>This is the components page.</p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill,minmax(200px,1fr))",
+          gap: "20px",
+        }}
+      >
+        {demos.map((c) => (
+          <div
+            key={c.name}
+            style={{
+              border: "1px solid #ddd",
+              padding: "20px",
+              cursor: "pointer",
+              textAlign: "center",
+            }}
+            onClick={() => handleOpen(c)}
+          >
+            {c.name}
+          </div>
+        ))}
+      </div>
+      <Dialog open={open} onClose={handleClose} maxWidth="md">
+        <Grid style={{ padding: 20 }}>{current?.component}</Grid>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make `/components` page list demos
- add scroll video component that plays frames based on scroll position
- link to `/components` via Next.js `Link` for SPA navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b216f6e308326a4ae48242d3d6c48